### PR TITLE
fixed build script on fedora

### DIFF
--- a/build/build-gnu.sh
+++ b/build/build-gnu.sh
@@ -157,6 +157,7 @@ case $distro in
 	which pinentry || sudo yum install pinentry
 	which fetchmail || sudo yum install fetchmail
 	which wipe || sudo yum install wipe
+	which abook || sudo yum install abook
 
 	echo "Checking build dependencies"
 	which gcc || sudo yum install gcc


### PR DESCRIPTION
checking if abook is installed
missing compile flags for date parser
dependencies are checked with rpm -q pkg_name
added dependency check for bzip2-devel and zlib-devel
