### PR TITLE
Added support for Arch Linux.

### DIFF
--- a/build/build-gnu.sh
+++ b/build/build-gnu.sh
@@ -8,6 +8,7 @@ cc="gcc -O3"
 
 which apt-get > /dev/null && distro=debian
 which yum > /dev/null && distro=fedora
+which pacman > /dev/null && distro=arch
 
 target=all
 { test -z $1 } || { target="$1" }
@@ -65,6 +66,10 @@ debian_req() {
         rpm -q zlib-devel || sudo yum install zlib-devel
 
         ;;
+
+    arch)
+        print "All dependencies installed via pacman/AUR"
+        print "Building on Arch..."
 
     *)
         print "Error: no distro recognized, build by hand."

--- a/build/build-gnu.sh
+++ b/build/build-gnu.sh
@@ -70,6 +70,7 @@ debian_req() {
     arch)
         print "All dependencies installed via pacman/AUR"
         print "Building on Arch..."
+        ;;
 
     *)
         print "Error: no distro recognized, build by hand."


### PR DESCRIPTION
Wanted to add support for Arch Linux, because the builder breaks otherwise.

All dependencies are managed through pacman and the Arch User Repository.