### PR TITLE
add opmsg support

### DIFF
--- a/src/zlibs/filters
+++ b/src/zlibs/filters
@@ -543,6 +543,9 @@ source '$MAILDIRS/.mutt/mboxes'
 
 # extra settings for mutt-kz (notmuch enabled)
 source '$MAILDIRS/.mutt/notmuch'
+
+# opmsg support
+source '$MAILDIRS/.mutt/opmsg'
 EOF
 
 

--- a/src/zlibs/mutt
+++ b/src/zlibs/mutt
@@ -59,6 +59,32 @@ x_mutt() {
         return 1
     }
 
+	rm -f "$MAILDIRS/.mutt/opmsg"
+	touch "$MAILDIRS/.mutt/opmsg"
+	opmux_path="$(command -v opmux)" && {
+		cat <<EOF > "$MAILDIRS/.mutt/opmsg"
+set pgp_long_ids
+
+set pgp_decode_command="OPMUX_MUA=mutt ${opmux_path} --passphrase-fd 0 \
+	--quiet --batch --output - %f"
+set pgp_verify_command="OPMUX_MUA=mutt ${opmux_path} --quiet --batch \
+	--output - --verify %s %f"
+set pgp_decrypt_command="OPMUX_MUA=mutt ${opmux_path} --passphrase-fd 0 \
+	--quiet --batch --output - %f"
+
+set pgp_encrypt_only_command="${opmux_path} --batch --quiet --output - \
+	--encrypt --textmode --armor --always-trust -r '%r' %f"
+set pgp_encrypt_sign_command="${opmux_path} --passphrase-fd 0 --batch \
+	--quiet --textmode --output - --encrypt --sign %?a?-u %a? --armor \
+	--always-trust -r '%r' %f"
+
+set pgp_list_pubring_command="${opmux_path} --batch --quiet --with-colons \
+	--list-keys %r"
+
+set pgp_decryption_okay="^opmux: SUCCESS\.$"
+EOF
+	}
+	unset opmux_path
 
 	rm -f "$MAILDIRS/.mutt/notmuch"
 	touch "$MAILDIRS/.mutt/notmuch"


### PR DESCRIPTION
First in the series of PRs ;)

This is a drop-in replacement for the existing gpg setup.

Enables simultaneous use of opmsg and gpg. `opmux` is a helper program that integrates gpg with opmsg and chooses the correct application to handle the email being read.