### PR TITLE
perf: lazy-load generated filter cache on startup

### DIFF
--- a/extras/test/test-mutt-crypto.sh
+++ b/extras/test/test-mutt-crypto.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env zsh
+
+set -euo pipefail
+
+script_dir="${0:A:h}"
+source "${script_dir}/lib/test_helpers.zsh"
+test_setup "${0}"
+
+cleanup() {
+  test_cleanup
+}
+trap cleanup EXIT INT TERM
+
+command -v mutt >/dev/null 2>&1 || {
+  print -- "SKIP test-mutt-crypto.sh: missing mutt"
+  exit 0
+}
+
+muttrc="${tmp_root}/muttrc"
+cat > "${muttrc}" <<EOF
+source "${work_root}/mutt/crypto"
+EOF
+
+crypto_settings="$(mutt -F "${muttrc}" \
+  -Q crypt_use_gpgme \
+  -Q crypt_autosmime \
+  -Q smime_verify_command \
+  -Q smime_verify_opaque_command </dev/null)"
+
+assert_contains "${crypto_settings}" "crypt_use_gpgme is unset" "disable gpgme"
+assert_contains "${crypto_settings}" "crypt_autosmime is unset" "disable automatic smime"
+assert_contains "${crypto_settings}" 'smime_verify_command="/bin/false"' "fail fast smime verify"
+assert_contains "${crypto_settings}" 'smime_verify_opaque_command="/bin/false"' "fail fast opaque smime verify"

--- a/src/jaro
+++ b/src/jaro
@@ -245,6 +245,8 @@ main() {
     { option.is_set -R } && { muttflags+=" -R " }
     { option.is_set -f } && { FORCE=1 }
 
+    check_bin "$subcommand"
+
     # clean up options from param
     # PARAM=(${PARAM// -? /})
 
@@ -357,7 +359,6 @@ main() {
 }
 
 
-check_bin
 main $@
 # endgame NOERRORS
 # return $exitcode

--- a/src/mutt/crypto
+++ b/src/mutt/crypto
@@ -8,6 +8,14 @@ set pgp_auto_decode
 set pgp_strict_enc
 set pgp_verify_sig = yes
 
+# JaroMail configures classic PGP commands below.  Avoid mutt's GPGME
+# backend here because it also invokes gpgsm for S/MIME signatures and
+# can block message opening on attached smime.p7s files.
+unset crypt_use_gpgme
+unset crypt_autosmime
+set smime_verify_command="/bin/false"
+set smime_verify_opaque_command="/bin/false"
+
 # # CLEARTEXT INLINE GPG
 # set pgp_create_traditional = no
 # macro compose \cx "Fgpg --clearsign\nyy"

--- a/src/zlibs/addressbook
+++ b/src/zlibs/addressbook
@@ -171,6 +171,7 @@ sender_isknown() {
     local _mail_input="${body:-}"
     [[ -z "${_mail_input}" ]] && _mail_input="$(cat)"
 	if command -v maddr > /dev/null; then
+		mblaze_ensure
 		local email_regex="([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6})"
 		e_from=`print - "${_mail_input}" | maddr -h 'from' - | grep -oP "$email_regex"`
 		e_from=${e_from:l}

--- a/src/zlibs/bootstrap
+++ b/src/zlibs/bootstrap
@@ -142,8 +142,6 @@ bootstrap_root="${bootstrap_file:A:h:h}"
     # global variable for mutt options
     vars+=(muttflags)
 
-    autoload colors; colors
-
     # which command to use when creating dirs
     mkdir="`command -v mkdir` -m 700 -p"
 
@@ -170,8 +168,6 @@ bootstrap_root="${bootstrap_file:A:h:h}"
 
     # own mblaze workdir and init empty sequence
     export MBLAZE="$MAILDIRS/cache/mblaze"
-    mkdir -p "${MBLAZE}"
-    touch ${MBLAZE}/seq
 
     PATH="$WORKDIR/bin:$PATH"
 
@@ -239,51 +235,25 @@ bootstrap_root="${bootstrap_file:A:h:h}"
 }
 
 # binary programs recognition
-check_bin() {
-    # required programs
-    for req in pinentry fetchmail gpg msmtp; do
+check_required_bins() {
+    for req in "$@"; do
         isfound $req
         { test $? != 0 } && {
             error "Cannot find $req. Please install it."
             exit 1
         }
     done
+}
 
-    # make sure a gnupg dir exists
+ensure_gnupg_dir() {
     { test -r $HOME/.gnupg/pubring.gpg } || {
         ${=mkdir} $HOME/.gnupg
         touch $HOME/.gnupg/pubring.gpg
         touch $HOME/.gnupg/secring.gpg
     }
+}
 
-    # which find command to use
-    case $OS in
-        GNU) find="find -O3" ;;
-        MAC) find="gfind -O3" ;;
-        *) find="find"
-    esac
-
-    # which wipe command to use
-    if  isfound wipe; then
-        rm="wipe -f -s -q -R /dev/urandom"
-    elif isfound srm; then
-        rm="srm -m"
-    else
-        rm="rm -f"
-    fi
-    func "Rm binary: $rm"
-
-    # which mutt binary to use
-    if isfound mutt; then
-        mutt_exec=mutt
-    elif isfound neomutt; then
-        mutt_exec=neomutt
-    fi
-    pgpewrap="${WORKDIR}/bin/gpgewrap"
-    dotlock="${WORKDIR}/bin/dotlock"
-
-    func "Mutt binary: $mutt_exec"
-    func "Notmuch binary: `command -v notmuch`"
+check_keyring() {
     func "Keyring set: $JARO_KEYRING"
     if [[ "$JARO_KEYRING" == "" ]]; then
         # check for pass, else fallback
@@ -324,6 +294,79 @@ check_bin() {
                 GNOMEKEY=1  ;;
         esac
     fi
+}
+
+ensure_mutt() {
+    if isfound mutt; then
+        mutt_exec=mutt
+    elif isfound neomutt; then
+        mutt_exec=neomutt
+    else
+        error "Cannot find mutt or neomutt. Please install one."
+        exit 1
+    fi
+    func "Mutt binary: $mutt_exec"
+}
+
+mblaze_ensure() {
+    export MBLAZE=${MBLAZE:-"$MAILDIRS/cache/mblaze"}
+    mkdir -p "${MBLAZE}"
+    touch "${MBLAZE}/seq"
+}
+
+check_bin() {
+    local cmd="${1:-$subcommand}"
+
+    # which find command to use
+    case $OS in
+        GNU) find="find -O3" ;;
+        MAC) find="gfind -O3" ;;
+        *) find="find"
+    esac
+
+    # which wipe command to use
+    if  isfound wipe; then
+        rm="wipe -f -s -q -R /dev/urandom"
+    elif isfound srm; then
+        rm="srm -m"
+    else
+        rm="rm -f"
+    fi
+    func "Rm binary: $rm"
+
+    pgpewrap="${WORKDIR}/bin/gpgewrap"
+    dotlock="${WORKDIR}/bin/dotlock"
+
+    case "$cmd" in
+        fetch)
+            check_required_bins pinentry fetchmail gpg
+            ensure_gnupg_dir
+            check_keyring
+            ;;
+        send|smtp)
+            check_required_bins pinentry gpg msmtp
+            ensure_gnupg_dir
+            check_keyring
+            ;;
+        peek|open|compose|__empty|__unknown:*)
+            ensure_mutt
+            [[ "$cmd" = "peek" ]] && {
+                check_required_bins pinentry gpg
+                ensure_gnupg_dir
+                check_keyring
+            }
+            ;;
+        passwd|askpass)
+            check_required_bins pinentry gpg
+            ensure_gnupg_dir
+            check_keyring
+            ;;
+        init|wizard)
+            check_required_bins pinentry gpg
+            ensure_gnupg_dir
+            check_keyring
+            ;;
+    esac
 
     return 0
 }

--- a/src/zlibs/filters
+++ b/src/zlibs/filters
@@ -33,8 +33,17 @@
 #  8. All the rest                 -> unsorted
 #
 
-# load zsh filter cache arrays
-test -r  "$MAILDIRS/cache/filters" && {
+# Load zsh filter cache arrays only for commands that need them.
+load_filter_cache() {
+    fn load_filter_cache
+
+    typeset -gAl  filter_from
+    typeset -galU filter_own
+    typeset -gAl  filter_to
+    typeset -galU filter_whitelist
+    typeset -galU filter_blacklist
+
+    [[ -r "$MAILDIRS/cache/filters" ]] || return 1
     source "$MAILDIRS/cache/filters"
 }
 
@@ -230,8 +239,7 @@ filter_maildir() {
   maildirmake "$MAILDIRS/unsorted"
 
   # loads up the filter cache (zsh compiled arrays)
-  [[ -r "$MAILDIRS/cache/filters" ]] &&
-    source $MAILDIRS/cache/filters
+  load_filter_cache
 
   mails="$(maildir_list_messages "$srcpath")"
   numm=`print $mails | wc -l`
@@ -551,6 +559,8 @@ update_sieve() {
 
     #######
     # SIEVE
+    load_filter_cache
+
     act "generate sieve filter rules"
     id=`datestamp`.$RANDOM
     newlock "$MAILDIRS/Filters.sieve"

--- a/src/zlibs/filters
+++ b/src/zlibs/filters
@@ -251,6 +251,7 @@ filter_maildir() {
 
   notice "Filtering maildir: $mdinput ($numm mails)"
   c=0
+  mblaze_ensure
 
   for m in ${(f)mails}; do
 

--- a/src/zlibs/keyring
+++ b/src/zlibs/keyring
@@ -24,6 +24,11 @@
 # pass wrapper to set all env
 _pass() {
 	fn pass $*
+	[[ -t 0 ]] && {
+		export GPG_TTY=$(tty)
+		command -v gpg-connect-agent >/dev/null 2>&1 &&
+			gpg-connect-agent updatestartuptty /bye >/dev/null 2>&1
+	}
 	PASSWORD_STORE_DIR=$PASSWORD_STORE_DIR pass $*
 }
 

--- a/src/zlibs/maildirs
+++ b/src/zlibs/maildirs
@@ -54,6 +54,7 @@ maildirmake() {
 
 	# use mblaze if found
 	command -v mmkdir > /dev/null && {
+        mblaze_ensure
 		mmkdir "$1"
 		return $?
 	}
@@ -90,6 +91,7 @@ maildir_list_messages() {
     maildircheck "$md" || return 1
 
     if command -v mlist >/dev/null; then
+        mblaze_ensure
         mlist "$md"
         return $?
     fi
@@ -108,6 +110,7 @@ maildir_list_folders() {
     [[ -d "$root" ]] || return 1
 
     if command -v mdirs >/dev/null; then
+        mblaze_ensure
         local folders
         folders="$(mdirs -a "$root")"
         for folder in ${(f)folders}; do
@@ -134,6 +137,7 @@ maildir_refile() {
     maildircheck "$dest" || maildirmake "$dest" || return 1
 
     if command -v mrefile >/dev/null; then
+        mblaze_ensure
         if [[ "$mode" == "copy" ]]; then
             mrefile -k "$msg" "$dest"
         else
@@ -240,6 +244,7 @@ deliver() {
 
 	# use mblaze if found
     command -v mdeliver > /dev/null && {
+        mblaze_ensure
 		last_deliver=`mdeliver -v "$MAILDIRS/$dest"`
 		local ret=$?
 		[[ $ret == 0 ]] || {

--- a/src/zlibs/parse
+++ b/src/zlibs/parse
@@ -25,6 +25,7 @@
 
 # extract all addresses found in a list of email files from stdin
 mblaze_extract_addresses() {
+    mblaze_ensure
     _action="${1:-all}"
     case "${_action}" in
         sender)


### PR DESCRIPTION
## Summary
- stop sourcing `$MAILDIRS/cache/filters` when loading the filters library
- add `load_filter_cache` and call it only from filter/sieve paths that need generated filter arrays
- move runtime checks after command parsing and scope them to commands that need keyring, GnuPG, fetchmail, msmtp, or mutt
- remove duplicate `colors` initialization from bootstrap
- avoid creating/touching the mblaze sequence directory at startup; initialize it lazily before mblaze commands run
- disable mutt's GPGME/S/MIME auto handling by default so attached `smime.p7s` signatures fail fast instead of blocking message opening
- refresh the GPG agent TTY before invoking `pass`, so `!jaro send` from inside mutt can decrypt the stored SMTP password instead of prompting again

## Measured locally
- before: installed `jaro -q source addr` around 20s on the real mailbox
- after lazy filter cache: source-tree `jaro -q source addr` around 0.05s
- after scoped checks/lazy mblaze: source-tree `jaro -q source addr` around 0.04s
- source-tree `jaro -q -a jaromil@dyne.org askpass` remains under 1s

## Validation
- `make`
- `zsh extras/test/run-source.sh`
- `zsh extras/test/test-mutt-crypto.sh`
- `zsh extras/test/test-filtering.sh`
- `zsh extras/test/test-sieve-import.sh`
- `zsh extras/test/test-maildir-commands.sh`
- `zsh extras/test/test-addressbook-parse.sh`
- `zsh extras/test/test-account-wizard.sh`
